### PR TITLE
add support for ALIAS and CAA resource records

### DIFF
--- a/host.go
+++ b/host.go
@@ -14,8 +14,7 @@ const (
 
 var (
 	allowedRecordTypes = []string{
-		// TODO(adam): CAA?
-		"A", "AAAA", "CNAME", "MX", "MXE", "TXT", "URL", "URL301", "FRAME",
+		"A", "AAAA", "ALIAS", "CAA", "CNAME", "MX", "MXE", "TXT", "URL", "URL301", "FRAME",
 	}
 )
 


### PR DESCRIPTION
> Possible values: A, AAAA, ALIAS, CAA, CNAME, MX, MXE, NS, TXT, URL, URL301, FRAME

https://www.namecheap.com/support/api/methods/domains-dns/set-hosts/